### PR TITLE
Create seperate tags for the module and the actions

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -28,7 +28,18 @@ jobs:
         additionalArguments: |
           /overrideconfig increment=patch
 
+    # create the SemVer tag
     - uses: hole19/git-tag-action@master
       env:
         TAG: ${{ steps.gitversion.outputs.semver }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Create the tags used for the actions
+    - uses: hole19/git-tag-action@master
+      env:
+        TAG: v${{ steps.gitversion.outputs.semver }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: hole19/git-tag-action@master
+      env:
+        TAG: v${{ steps.gitversion.outputs.major }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,9 @@ jobs:
     needs:
     - run_tests
     - run_gitversion
-    if: startsWith(github.ref, 'refs/tags')
+    # only trigger for tags with the strict SemVer format, not the tag used by the actions (i.e. v1)
+    if: |
+      (startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/v'))
     steps:
     - uses: actions/checkout@v2
     - run: |
@@ -46,4 +48,3 @@ jobs:
         Publish-Module -Name .\module\Endjin.PRAutoflow.psd1 -NuGetApiKey ${{ secrets.ENDJIN_PSGALLERY_APIKEY }} -Verbose
       shell: pwsh
       name: Publish module
-    


### PR DESCRIPTION
We require a strict SemVer tag in order to pass the version number between workflows.  However, the convention for github actions is to have a 'v' prefix.

We also now create a movable tag that tracks the latest version of a major release.