### PR TITLE
Do not throw an exception when processing a non-Dependabot PR

### DIFF
--- a/module/functions/AnyInterestingPRs.Tests.ps1
+++ b/module/functions/AnyInterestingPRs.Tests.ps1
@@ -149,5 +149,15 @@ Describe 'AnyInterestingPRs Tests' -Tag Unit {
         }
     }
 
+    Context 'User PRs' {
+        It 'should return false when processing a normal user-initiated PR' {
+            $res = AnyInterestingPRs -Titles @('Fixes a nasty bug!') `
+                                    -MaxSemVerIncrement 'patch' `
+                                    -PackageWildcardExpressions @("Endjin.*","Corvus.*")
+            $res | Should -BeOfType [boolean]
+            $res | Should -Be $false  
+        }
+    }
+
 
 }

--- a/module/functions/AnyInterestingPRs.ps1
+++ b/module/functions/AnyInterestingPRs.ps1
@@ -33,6 +33,11 @@ function AnyInterestingPRs
         
         # parse the PR title
         $packageName,$fromVersion,$toVersion,$folder = ParsePrTitle -Title $prTitle
+        # For non-Dependabot PRs we won't get a parsed title back, but this is fine.  For normal user PRs
+        # don't expect to have to wait for other related, in-flights PR to finish (like we do for Dependabot PRs)
+        if (!$packageName) {
+            break;
+        }
         Write-Verbose ('Package: {0}' -f $packageName)
 
         # apply package filter

--- a/module/functions/ParsePrTitle.Tests.ps1
+++ b/module/functions/ParsePrTitle.Tests.ps1
@@ -4,8 +4,9 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 
 Describe 'ParsePrTitle Tests' -Tag Unit {
     
-    It 'should fail when parsing a non-Dependabot PR' {
-        { ParsePrTitle -Title 'My very own PR' }  | Should -Throw
+    It 'should return null when parsing a non-Dependabot PR' {
+        $res = ParsePrTitle -Title 'My very own PR'
+        $res | Should -Be $null
     }
 
     Context 'Extracting PR details' {

--- a/module/functions/ParsePrTitle.ps1
+++ b/module/functions/ParsePrTitle.ps1
@@ -23,6 +23,7 @@ function ParsePrTitle
         $res.Groups[4].Value
     }
     else {
-        throw ("Could not parse the PR title '{0}' - must be a PR raised by Dependabot" -f $Title)
+        Write-Host "Not a Dependabot PR"
+        return @()
     }
 }


### PR DESCRIPTION
This will enable the auto-release functionality to be used for manual pull requests